### PR TITLE
Fix command line in Data Plane API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ userlist haproxy-dataplaneapi
     user admin insecure-password mypassword
 
 program api
-   command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
+   command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --userlist haproxy-dataplaneapi
    no option start-on-reload
 ```
 


### PR DESCRIPTION
The example `docker run` command mounts the haproxy config file in `/usr/local/etc/haproxy`, but the Data Plane API command is stated as sourcing the config file in `/etc/haproxy`, causing the example code/commands to fail starting haproxy.